### PR TITLE
Console wrapper: fixed example method input in README.md

### DIFF
--- a/console/wrapper/README.md
+++ b/console/wrapper/README.md
@@ -28,7 +28,7 @@ In code:
 import { Console_Query } from "./w3";
 
 function customMethod(): bool {
-  Console_Query.info("some useful info about my API");
+  Console_Query.info({ message: "some useful info about my API" });
 
   return true;
 }


### PR DESCRIPTION
updated readme to use correct input for the example method call