### PR TITLE
Fix `near-interface` project type

### DIFF
--- a/protocol/near/near-interface/polywrap.yaml
+++ b/protocol/near/near-interface/polywrap.yaml
@@ -1,5 +1,5 @@
 format: 0.1.0
 name: near-interface
-language: wasm/interface
+language: interface
 schema: ./schema.graphql
 deploy: ./polywrap.deploy.yaml

--- a/protocol/near/near-interface/polywrap.yaml
+++ b/protocol/near/near-interface/polywrap.yaml
@@ -1,5 +1,8 @@
-format: 0.1.0
-name: near-interface
-language: interface
-schema: ./schema.graphql
-deploy: ./polywrap.deploy.yaml
+format: 0.2.0
+project:
+  name: near-interface
+  type: interface
+source:
+  schema: ./schema.graphql
+extensions:
+  deploy: ./polywrap.deploy.yaml


### PR DESCRIPTION
Quick fix to the `type` field in the `near-interface` project manifest.

Additionally, project manifest has been migrated to `0.2.0`