### PR TITLE
Near wrapper enhancements

### DIFF
--- a/protocol/near/plugin-js/schema.graphql
+++ b/protocol/near/plugin-js/schema.graphql
@@ -47,8 +47,10 @@ type Module {
 }
 
 type ConnectionConfig {
+  networkId: String!
   nodeUrl: String!
   helperUrl: String
+  indexerServiceUrl: String
 }
 # Account public key data
 type PublicKey {

--- a/protocol/near/plugin-js/schema.graphql
+++ b/protocol/near/plugin-js/schema.graphql
@@ -48,6 +48,7 @@ type Module {
 
 type ConnectionConfig {
   nodeUrl: String!
+  helperUrl: String
 }
 # Account public key data
 type PublicKey {

--- a/protocol/near/plugin-js/src/index.ts
+++ b/protocol/near/plugin-js/src/index.ts
@@ -27,7 +27,9 @@ export { keyStores as KeyStores, KeyPair } from "near-api-js";
 
 export interface NearPluginConfig
   extends ConnectConfig,
-    Record<string, unknown> {}
+    Record<string, unknown> {
+  indexerServiceUrl?: string;
+}
 
 export class NearPlugin extends Module<NearPluginConfig> {
   private near: nearApi.Near;
@@ -60,7 +62,12 @@ export class NearPlugin extends Module<NearPluginConfig> {
   }
 
   public getConfig(): ConnectionConfig {
-    return { nodeUrl: this.config.nodeUrl, helperUrl: this.config.helperUrl };
+    return {
+      nodeUrl: this.config.nodeUrl,
+      helperUrl: this.config.helperUrl,
+      networkId: this.config.networkId,
+      indexerServiceUrl: this.config.indexerServiceUrl,
+    };
   }
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars

--- a/protocol/near/plugin-js/src/index.ts
+++ b/protocol/near/plugin-js/src/index.ts
@@ -60,7 +60,7 @@ export class NearPlugin extends Module<NearPluginConfig> {
   }
 
   public getConfig(): ConnectionConfig {
-    return { nodeUrl: this.config.nodeUrl };
+    return { nodeUrl: this.config.nodeUrl, helperUrl: this.config.helperUrl };
   }
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars

--- a/protocol/near/wrapper/package.json
+++ b/protocol/near/wrapper/package.json
@@ -16,6 +16,7 @@
     "test": "jest --passWithNoTests --runInBand --verbose",
     "test:read": "jest ./e2e/read.spec.ts --passWithNoTests --runInBand --verbose --silent=false",
     "test:write": "jest ./e2e/write.spec.ts --passWithNoTests --runInBand --verbose --silent=false",
+    "test:enhancements": "jest ./e2e/enhancements.spec.ts --passWithNoTests --runInBand --verbose --silent=false",
     "test:jsonRpcRequest": "jest ./e2e/jsonRpcRequests.spec.ts --passWithNoTests --runInBand --verbose --silent=false",
     "test:transactions": "jest ./e2e/transactions.spec.ts --passWithNoTests --runInBand --verbose --silent=false",
     "test:wallet": "jest ./e2e/wallet.spec.ts --passWithNoTests --runInBand --verbose --silent=false",

--- a/protocol/near/wrapper/package.json
+++ b/protocol/near/wrapper/package.json
@@ -16,7 +16,7 @@
     "test": "jest --passWithNoTests --runInBand --verbose",
     "test:read": "jest ./e2e/read.spec.ts --passWithNoTests --runInBand --verbose --silent=false",
     "test:write": "jest ./e2e/write.spec.ts --passWithNoTests --runInBand --verbose --silent=false",
-    "test:enhancements": "jest ./e2e/enhancements.spec.ts --passWithNoTests --runInBand --verbose --silent=false",
+    "test:fetch": "jest ./e2e/fetch.spec.ts --passWithNoTests --runInBand --verbose --silent=false",
     "test:jsonRpcRequest": "jest ./e2e/jsonRpcRequests.spec.ts --passWithNoTests --runInBand --verbose --silent=false",
     "test:transactions": "jest ./e2e/transactions.spec.ts --passWithNoTests --runInBand --verbose --silent=false",
     "test:wallet": "jest ./e2e/wallet.spec.ts --passWithNoTests --runInBand --verbose --silent=false",

--- a/protocol/near/wrapper/src/__tests__/e2e/fetch.spec.ts
+++ b/protocol/near/wrapper/src/__tests__/e2e/fetch.spec.ts
@@ -1,0 +1,179 @@
+import * as testUtils from "../testUtils";
+import {
+  /* KeyPair, */ KeyPair,
+  NearPluginConfig,
+} from "../../../../plugin-js/build"; //TODO change to appropriate package
+
+import { PolywrapClient } from "@polywrap/client-js";
+import {
+  ensAddresses,
+  initTestEnvironment,
+  providers,
+  stopTestEnvironment,
+} from "@polywrap/test-env-js";
+
+import "localstorage-polyfill";
+import { FinalExecutionOutcome } from "../tsTypes";
+
+const MockBrowser = require("mock-browser").mocks.MockBrowser;
+const mock = new MockBrowser();
+
+global["document"] = mock.getDocument();
+global["window"] = mock.getWindow();
+global["localStorage"] = localStorage;
+
+jest.setTimeout(360000);
+
+describe("Write operations", () => {
+  let client: PolywrapClient;
+  let apiUri: string;
+  let nearConfig: NearPluginConfig;
+
+  beforeAll(async () => {
+    // set up test env and deploy api
+    await initTestEnvironment();
+    nearConfig = await testUtils.setUpTestConfig();
+
+    // set up client
+    const absPath = __dirname + "/../../../build";
+    apiUri = `fs/${absPath}`;
+    const polywrapConfig = testUtils.getPlugins(
+      providers.ethereum,
+      ensAddresses.ensAddress,
+      providers.ipfs,
+      nearConfig
+    );
+    client = new PolywrapClient(polywrapConfig);
+  });
+
+  afterAll(async () => {
+    await stopTestEnvironment();
+  });
+
+  test("Should create master account", async () => {
+    const newAccountId = testUtils.generateUniqueString("test");
+
+    const publicKey = KeyPair.fromRandom("ed25519").getPublicKey();
+
+    const result = await client.invoke<FinalExecutionOutcome>({
+      uri: apiUri,
+      method: "createMasterAccount",
+      args: {
+        newAccountId,
+        publicKey,
+      },
+    });
+
+    expect(result.error).toBeFalsy();
+    expect(result.data).toBeTruthy();
+
+    const creationResult = result.data!;
+    expect(creationResult).toBeTruthy();
+
+    expect(creationResult.status).toBeTruthy();
+    expect(creationResult.status.SuccessValue).toBeDefined();
+    expect(creationResult.status.failure).toBeFalsy();
+  });
+
+  test("Should get stacking deposits", async () => {
+    const result = await client.invoke<string>({
+      uri: apiUri,
+      method: "getStakingDeposits",
+      args: {
+        accountId: testUtils.testAccountId,
+      },
+    });
+
+    expect(result).toBeTruthy();
+
+    expect(result.data).toBeTruthy();
+    expect(result.error).toBeFalsy();
+
+    const data = JSON.parse(result.data!);
+
+    expect(data).toBeInstanceOf(Array);
+  });
+
+  test("Should get NFTs contracts", async () => {
+    const result = await client.invoke<string>({
+      uri: apiUri,
+      method: "listLikelyNftsContracts",
+      args: {
+        accountId: testUtils.testAccountId,
+      },
+    });
+
+    expect(result).toBeTruthy();
+
+    expect(result.data).toBeTruthy();
+    expect(result.error).toBeFalsy();
+
+    const data = JSON.parse(result.data!);
+
+    expect(data.lastBlockTimestamp).toBeTruthy();
+    expect(data.version).toBeTruthy();
+    expect(data.list).toBeInstanceOf(Array);
+  });
+
+  test("Should get Fungible Tokens contracts", async () => {
+    const result = await client.invoke<string>({
+      uri: apiUri,
+      method: "likelyTokensFromBlock",
+      args: {
+        accountId: testUtils.testAccountId,
+      },
+    });
+
+    expect(result).toBeTruthy();
+
+    expect(result.data).toBeTruthy();
+    expect(result.error).toBeFalsy();
+
+    const data = JSON.parse(result.data!);
+
+    expect(data.lastBlockTimestamp).toBeTruthy();
+    expect(data.version).toBeTruthy();
+    expect(data.list).toBeInstanceOf(Array);
+  });
+
+  test("Should get accounts bound to stringified Public Key", async () => {
+    const ledgerPK = "ed25519:FTYCHJXSu68f3thsKtjuuFkjePw4XbfdZyP763uBNdx5";
+    const ledgerAccountId =
+      "d6cffd5f97babaf6226e944fb0dde03bda6b2bc3d91e665b724dbf6ea10754f2";
+    const result = await client.invoke<string>({
+      uri: apiUri,
+      method: "accountsAtPublicKey",
+      args: {
+        publicKeyString: ledgerPK,
+      },
+    });
+
+    expect(result).toBeTruthy();
+
+    expect(result.data).toBeTruthy();
+    expect(result.error).toBeFalsy();
+
+    const data = JSON.parse(result.data!);
+
+    expect(data).toContain(ledgerAccountId);
+  });
+
+  test("Should get near to usd ratio", async () => {
+    const result = await client.invoke<{
+      usd: string;
+      last_updated_at: string;
+    }>({
+      uri: apiUri,
+      method: "nearToUsdRatio",
+    });
+
+    expect(result).toBeTruthy();
+
+    expect(result.data).toBeTruthy();
+    expect(result.error).toBeFalsy();
+
+    const data = result.data;
+    expect(data?.usd).toBeTruthy();
+    expect(data?.last_updated_at).toBeTruthy();
+  });
+});

--- a/protocol/near/wrapper/src/__tests__/e2e/fetch.spec.ts
+++ b/protocol/near/wrapper/src/__tests__/e2e/fetch.spec.ts
@@ -15,16 +15,10 @@ import {
 import "localstorage-polyfill";
 import { FinalExecutionOutcome } from "../tsTypes";
 
-const MockBrowser = require("mock-browser").mocks.MockBrowser;
-const mock = new MockBrowser();
-
-global["document"] = mock.getDocument();
-global["window"] = mock.getWindow();
-global["localStorage"] = localStorage;
 
 jest.setTimeout(360000);
 
-describe("Write operations", () => {
+describe("Fetch operations", () => {
   let client: PolywrapClient;
   let apiUri: string;
   let nearConfig: NearPluginConfig;

--- a/protocol/near/wrapper/src/__tests__/e2e/write.spec.ts
+++ b/protocol/near/wrapper/src/__tests__/e2e/write.spec.ts
@@ -351,34 +351,4 @@ describe("Write operations", () => {
     expect(functionResult.status.failure).toBeFalsy();
     expect(functionResult.status.SuccessValue).toBeDefined();
   });
-
-  test("Should create master account", async () => {
-    const newAccountId = testUtils.generateUniqueString("test");
-
-    const accountToCreate = await near.account(newAccountId);
-    
-    expect(accountToCreate.state()).rejects.toThrow();
-    
-    const publicKey = KeyPair.fromRandom("ed25519").getPublicKey();
-
-    const result = await client.invoke({
-      uri: apiUri,
-      method: "createMasterAccount",
-      args: {
-        newAccountId,
-        publicKey,
-      },
-    });
-
-    expect(result.error).toBeFalsy();
-    expect(result.data).toBeTruthy();
-
-    const creationResult = result.data;
-
-    expect(creationResult).toBeTruthy();
-
-    const accountCreated = await near.account(newAccountId);
-
-    expect(accountCreated.state()).resolves;
-  });
 });

--- a/protocol/near/wrapper/src/__tests__/e2e/write.spec.ts
+++ b/protocol/near/wrapper/src/__tests__/e2e/write.spec.ts
@@ -351,4 +351,34 @@ describe("Write operations", () => {
     expect(functionResult.status.failure).toBeFalsy();
     expect(functionResult.status.SuccessValue).toBeDefined();
   });
+
+  test("Should create master account", async () => {
+    const newAccountId = testUtils.generateUniqueString("test");
+
+    const accountToCreate = await near.account(newAccountId);
+    
+    expect(accountToCreate.state()).rejects.toThrow();
+    
+    const publicKey = KeyPair.fromRandom("ed25519").getPublicKey();
+
+    const result = await client.invoke({
+      uri: apiUri,
+      method: "createMasterAccount",
+      args: {
+        newAccountId,
+        publicKey,
+      },
+    });
+
+    expect(result.error).toBeFalsy();
+    expect(result.data).toBeTruthy();
+
+    const creationResult = result.data;
+
+    expect(creationResult).toBeTruthy();
+
+    const accountCreated = await near.account(newAccountId);
+
+    expect(accountCreated.state()).resolves;
+  });
 });

--- a/protocol/near/wrapper/src/__tests__/testUtils.ts
+++ b/protocol/near/wrapper/src/__tests__/testUtils.ts
@@ -42,6 +42,7 @@ export async function setUpTestConfig(): Promise<NearPluginConfig> {
     nodeUrl: "https://rpc.testnet.near.org",
     walletUrl: "https://wallet.testnet.near.org",
     helperUrl: "https://helper.testnet.near.org",
+    indexerServiceUrl: "https://testnet-api.kitwallet.app",
     masterAccount: testAccountId,
     initialBalance: "1100000000000000000000000",
   };

--- a/protocol/near/wrapper/src/index.ts
+++ b/protocol/near/wrapper/src/index.ts
@@ -3,3 +3,4 @@ export * from "./modules/read";
 export * from "./modules/format"
 export * from "./modules/wallet"
 export * from "./modules/write"
+export * from "./modules/fetch"

--- a/protocol/near/wrapper/src/modules/fetch.ts
+++ b/protocol/near/wrapper/src/modules/fetch.ts
@@ -1,0 +1,96 @@
+import { JSON, JSONEncoder } from "@polywrap/wasm-as";
+import fetchJson from "../utils/fetchJson";
+import { toFinalExecutionOutcome, toUsdRatio } from "../utils/jsonMap";
+import { publicKeyToStr } from "../utils/typeUtils";
+import {
+  Args_createMasterAccount,
+  Interface_FinalExecutionOutcome,
+  Near_Module,
+  UsdRatio,
+} from "../wrap";
+import {
+  Args_accountsAtPublicKey,
+  Args_getStakingDeposits,
+  Args_likelyTokensFromBlock,
+  Args_listLikelyNftsContracts,
+  Args_nearToUsdRatio,
+} from "../wrap/Module/serialization";
+
+export function createMasterAccount(
+  args: Args_createMasterAccount
+): Interface_FinalExecutionOutcome {
+  const helperUrl = Near_Module.getConfig({}).unwrap().helperUrl;
+
+  if (helperUrl != null) {
+    const encoder = new JSONEncoder();
+    encoder.pushObject(null);
+    encoder.setString("newAccountId", args.newAccountId);
+    encoder.setString("newAccountPublicKey", publicKeyToStr(args.publicKey));
+    encoder.popObject();
+    const result = fetchJson(`${helperUrl!}/account`, encoder.toString());
+    return toFinalExecutionOutcome(<JSON.Obj>result);
+  }
+  throw Error("No helper url specified in plugin config");
+}
+
+export function getStakingDeposits(args: Args_getStakingDeposits): JSON.Value {
+  const indexerServiceUrl = Near_Module.getConfig({}).unwrap()
+    .indexerServiceUrl;
+  if (indexerServiceUrl != null) {
+    return fetchJson(
+      `${indexerServiceUrl!}/staking-deposits/${args.accountId}`,
+      null
+    );
+  }
+  throw Error("No helper url specified in plugin config");
+}
+
+export function listLikelyNftsContracts(
+  args: Args_listLikelyNftsContracts
+): JSON.Value {
+  const indexerServiceUrl = Near_Module.getConfig({}).unwrap()
+    .indexerServiceUrl;
+  if (indexerServiceUrl != null) {
+    return fetchJson(
+      `${indexerServiceUrl!}/account/${args.accountId}/likelyNFTsFromBlock`,
+      null
+    );
+  }
+  throw Error("No helper url specified in plugin config");
+}
+
+export function likelyTokensFromBlock(
+  args: Args_likelyTokensFromBlock
+): JSON.Value {
+  const indexerServiceUrl = Near_Module.getConfig({}).unwrap()
+    .indexerServiceUrl;
+  if (indexerServiceUrl != null) {
+    return fetchJson(
+      `${indexerServiceUrl!}/account/${args.accountId}/likelyTokensFromBlock`,
+      null
+    );
+  }
+  throw Error("No helper url specified in plugin config");
+}
+
+export function accountsAtPublicKey(
+  args: Args_accountsAtPublicKey
+): JSON.Value {
+  const indexerServiceUrl = Near_Module.getConfig({}).unwrap()
+    .indexerServiceUrl;
+  if (indexerServiceUrl != null) {
+    return fetchJson(
+      `${indexerServiceUrl!}/publicKey/${args.publicKeyString}/accounts`,
+      null
+    );
+  }
+  throw Error("No helper url specified in plugin config");
+}
+
+export function nearToUsdRatio(args: Args_nearToUsdRatio): UsdRatio | null {
+  const result = fetchJson(
+    "https://api.coingecko.com/api/v3/simple/price?ids=near&include_last_updated_at=true&vs_currencies=usd",
+    null
+  );
+  return toUsdRatio(<JSON.Obj>result);
+}

--- a/protocol/near/wrapper/src/modules/write.ts
+++ b/protocol/near/wrapper/src/modules/write.ts
@@ -24,6 +24,7 @@ import {
   Interface_FinalExecutionOutcome,
   Near_Near_Action,
   Borsh_Module,
+  Args_createMasterAccount,
 } from "../wrap";
 import * as bs58 from "as-base58";
 import * as bs64 from "as-base64";
@@ -32,6 +33,7 @@ import {
   fullAccessKey,
   functionCallAccessKey,
   publicKeyFromStr,
+  publicKeyToStr,
 } from "../utils/typeUtils";
 import { toFinalExecutionOutcome } from "../utils/jsonMap";
 
@@ -41,10 +43,12 @@ import * as NEAR_READ from "../modules/read";
 import {
   fromPluginTransaction,
   toPluginAction,
+  toPluginPublicKey,
   toPluginTransaction,
 } from "../utils/typeMapping";
 import JsonRpcProvider from "../utils/JsonRpcProvider";
 import { toBorshSignedTransaction, toBorshTransaction } from "../utils/toBorsh";
+import fetchJson from "../utils/fetchJson";
 
 export function createTransaction(
   args: Args_createTransaction
@@ -113,6 +117,20 @@ export function createTransaction(
     blockHash: blockHash,
     actions: args.actions,
   };
+}
+
+export function createMasterAccount(args: Args_createMasterAccount): JSON.Obj {
+  const helperUrl = Near_Module.getConfig({}).unwrap().helperUrl;
+  const encoder = new JSONEncoder()
+  encoder.pushObject(null)
+  encoder.setString('newAccountId', args.newAccountId)
+  encoder.setString('newAccountPublicKey', publicKeyToStr(args.publicKey))
+  encoder.popObject()
+
+  if (!helperUrl == null) {
+    return fetchJson(helperUrl + '/account', encoder.toString())
+  }
+  throw Error("No helper url specified in plugin config");
 }
 
 export function signTransaction(

--- a/protocol/near/wrapper/src/modules/write.ts
+++ b/protocol/near/wrapper/src/modules/write.ts
@@ -33,22 +33,15 @@ import {
   fullAccessKey,
   functionCallAccessKey,
   publicKeyFromStr,
-  publicKeyToStr,
 } from "../utils/typeUtils";
 import { toFinalExecutionOutcome } from "../utils/jsonMap";
 
 import * as action from "../utils/actionCreators";
 import * as NEAR_READ from "../modules/read";
 
-import {
-  fromPluginTransaction,
-  toPluginAction,
-  toPluginPublicKey,
-  toPluginTransaction,
-} from "../utils/typeMapping";
+import { fromPluginTransaction, toPluginAction } from "../utils/typeMapping";
 import JsonRpcProvider from "../utils/JsonRpcProvider";
 import { toBorshSignedTransaction, toBorshTransaction } from "../utils/toBorsh";
-import fetchJson from "../utils/fetchJson";
 
 export function createTransaction(
   args: Args_createTransaction
@@ -117,20 +110,6 @@ export function createTransaction(
     blockHash: blockHash,
     actions: args.actions,
   };
-}
-
-export function createMasterAccount(args: Args_createMasterAccount): JSON.Obj {
-  const helperUrl = Near_Module.getConfig({}).unwrap().helperUrl;
-  const encoder = new JSONEncoder()
-  encoder.pushObject(null)
-  encoder.setString('newAccountId', args.newAccountId)
-  encoder.setString('newAccountPublicKey', publicKeyToStr(args.publicKey))
-  encoder.popObject()
-
-  if (!helperUrl == null) {
-    return fetchJson(helperUrl + '/account', encoder.toString())
-  }
-  throw Error("No helper url specified in plugin config");
 }
 
 export function signTransaction(

--- a/protocol/near/wrapper/src/schema.graphql
+++ b/protocol/near/wrapper/src/schema.graphql
@@ -174,6 +174,11 @@ type Module {
         params: JSON!
     ): JSON!
 
+    createMasterAccount(
+        newAccountId: String!
+        publicKey: Interface_PublicKey!
+    ): JSON!
+
     """
     Generic Mutation Functions
     """
@@ -212,7 +217,7 @@ type Module {
         signerId: String!
     ): String!
 
-    # create a new Near account
+    # create a new Near account from Master
     createAccount(
         newAccountId: String!
         publicKey: Interface_PublicKey! # | String

--- a/protocol/near/wrapper/src/schema.graphql
+++ b/protocol/near/wrapper/src/schema.graphql
@@ -73,6 +73,8 @@ type Module {
         receiverId: String!
         actions: [Interface_Action!]!
         signerId: String
+        publicKey: Interface_PublicKey
+        nonce: BigInt
     ): Interface_Transaction!
 
     # signs a transaction without wallet

--- a/protocol/near/wrapper/src/schema.graphql
+++ b/protocol/near/wrapper/src/schema.graphql
@@ -174,10 +174,34 @@ type Module {
         params: JSON!
     ): JSON!
 
+    """
+    Fetch Requests
+    """    
     createMasterAccount(
         newAccountId: String!
         publicKey: Interface_PublicKey!
+    ): Interface_FinalExecutionOutcome!
+
+    getStakingDeposits(
+        accountId: String!
     ): JSON!
+
+    # Returns contract addresses of account NFT's
+    listLikelyNftsContracts(
+        accountId: String!
+    ): JSON!
+
+    # Returns contract addresses of account fungible tokens
+    likelyTokensFromBlock(
+        accountId: String!
+    ): JSON!
+
+    # Returns account bound to stringified public key
+    accountsAtPublicKey(
+        publicKeyString: String!
+    ): JSON!
+
+    nearToUsdRatio: UsdRatio
 
     """
     Generic Mutation Functions
@@ -590,4 +614,9 @@ type Receipt {
 
 type ActionContainer {
   actions: [Interface_Action!]!
+}
+
+type UsdRatio {
+    usd: String!
+    last_updated_at: BigInt!
 }

--- a/protocol/near/wrapper/src/utils/fetchJson.ts
+++ b/protocol/near/wrapper/src/utils/fetchJson.ts
@@ -1,0 +1,34 @@
+import { JSON } from "@polywrap/wasm-as";
+import { HTTP_Module, HTTP_ResponseType } from "../wrap";
+
+
+export function fetchJson(url: string, json: string): JSON.Obj {
+  const response = HTTP_Module.post({
+    url: url,
+    request: {
+      headers: [
+        {
+          key: "Content-Type",
+          value: "application/json",
+        },
+      ],
+      responseType: HTTP_ResponseType.TEXT,
+      urlParams: null,
+      body: json,
+    },
+  }).unwrap();
+
+  if (!response || response.status !== 200 || !response.body) {
+    const errorMsg =
+      response && response.statusText
+        ? (response.statusText as string)
+        : "An error occurred while fetching data from Avalanche API";
+    throw new Error(errorMsg);
+  }
+
+  const data = <JSON.Obj>JSON.parse(response.body);
+
+  return data;
+}
+
+export default fetchJson;

--- a/protocol/near/wrapper/src/utils/fetchJson.ts
+++ b/protocol/near/wrapper/src/utils/fetchJson.ts
@@ -1,32 +1,45 @@
 import { JSON } from "@polywrap/wasm-as";
-import { HTTP_Module, HTTP_ResponseType } from "../wrap";
+import { HTTP_Module, HTTP_Response, HTTP_ResponseType } from "../wrap";
 
+export function fetchJson(url: string, json: string | null): JSON.Value {
+  let response: HTTP_Response | null;
 
-export function fetchJson(url: string, json: string): JSON.Obj {
-  const response = HTTP_Module.post({
-    url: url,
-    request: {
-      headers: [
-        {
-          key: "Content-Type",
-          value: "application/json",
-        },
-      ],
-      responseType: HTTP_ResponseType.TEXT,
-      urlParams: null,
-      body: json,
-    },
-  }).unwrap();
+  if (json != null) {
+    response = HTTP_Module.post({
+      url: url,
+      request: {
+        headers: [
+          {
+            key: "Content-Type",
+            value: "application/json",
+          },
+        ],
+        responseType: HTTP_ResponseType.TEXT,
+        urlParams: null,
+        body: json,
+      },
+    }).unwrap();
+  } else {
+    response = HTTP_Module.get({
+      url: url,
+      request: {
+        headers: null,
+        urlParams: null,
+        body: null,
+        responseType: HTTP_ResponseType.TEXT,
+      },
+    }).unwrap();
+  }
 
   if (!response || response.status !== 200 || !response.body) {
     const errorMsg =
       response && response.statusText
         ? (response.statusText as string)
-        : "An error occurred while fetching data from Avalanche API";
+        : "An error occurred while fetching data";
     throw new Error(errorMsg);
   }
 
-  const data = <JSON.Obj>JSON.parse(response.body);
+  const data = JSON.parse(response.body);
 
   return data;
 }

--- a/protocol/near/wrapper/src/utils/jsonMap.ts
+++ b/protocol/near/wrapper/src/utils/jsonMap.ts
@@ -33,6 +33,7 @@ import {
   Interface_TransactionWithHash,
   Interface_FinalExecutionOutcome,
   Interface_AccessKeyPermission,
+  UsdRatio,
 } from "../wrap";
 import { BigInt, JSON, JSONEncoder } from "@polywrap/wasm-as";
 import { publicKeyFromStr } from "./typeUtils";
@@ -691,6 +692,20 @@ function toExecutionStatus(json: JSON.Obj): Interface_ExecutionStatus {
     result.failure = failure;
   }
   return result;
+}
+
+export function toUsdRatio(json: JSON.Obj): UsdRatio | null {
+  const near = json.getObj("near");
+  if (near == null) {
+    return null;
+  }
+  const usd = near.getNum("usd")!.valueOf();
+  const last_updated_at = near.getInteger("last_updated_at")!.valueOf();
+
+  return {
+    usd: usd.toString(),
+    last_updated_at: BigInt.from(last_updated_at),
+  };
 }
 
 function toBase64String(value: string): string {


### PR DESCRIPTION
Additional functionality implementation:

Fetch requests to :
- Create account without using master account (already created)
To receive:
  - staking deposits of account
  - tokens of account
  - nfts of account
  - accounts, bounded to public key (in string format)
  - near to usd ratio